### PR TITLE
{RDBMS} Fix delete restored servers in pipeline tests

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_flexible_commands_pipeline.py
+++ b/src/azure-cli/azure/cli/command_modules/rdbms/tests/latest/test_rdbms_flexible_commands_pipeline.py
@@ -265,13 +265,14 @@ class FlexibleServerRegularMgmtScenarioTest(RdbmsScenarioTest):
         except:
             pytest.skip("source server not provisioned")
 
-        restore_time = datetime.utcnow().replace(tzinfo=tzutc()).isoformat()
-        self.cmd('{} flexible-server restore -g {} --name {} --source-server {} --restore-time {}'
-                .format(database_engine, resource_group, restore_server, server, restore_time),
-                checks=[JMESPathCheck('name', restore_server),
-                        JMESPathCheck('resourceGroup', resource_group)])
-
-        self.cmd('{} flexible-server delete -g {} --name {} --yes'.format(database_engine, resource_group, restore_server))
+        try:
+            restore_time = datetime.utcnow().replace(tzinfo=tzutc()).isoformat()
+            self.cmd('{} flexible-server restore -g {} --name {} --source-server {} --restore-time {}'
+                    .format(database_engine, resource_group, restore_server, server, restore_time),
+                    checks=[JMESPathCheck('name', restore_server),
+                            JMESPathCheck('resourceGroup', resource_group)])
+        finally:
+            self.cmd('{} flexible-server delete -g {} --name {} --yes'.format(database_engine, resource_group, restore_server))
     
     def _test_flexible_server_georestore(self, database_engine, resource_group, server, georestore_server):
     
@@ -420,20 +421,22 @@ class FlexibleServerHighAvailabilityMgmt(RdbmsScenarioTest):
             self.cmd('{} flexible-server show -g {} --name {}'.format(database_engine, resource_group, server))
         except:
             pytest.skip("source server not provisioned")
-        restore_time = datetime.utcnow().replace(tzinfo=tzutc()).isoformat()
-        if database_engine == 'postgres':
-            self.cmd('{} flexible-server restore -g {} --name {} --source-server {} --restore-time {}'
-                     .format(database_engine, resource_group, restore_server, server, restore_time),
-                     checks=[JMESPathCheck('name', restore_server),
-                             JMESPathCheck('resourceGroup', resource_group),
-                             JMESPathCheck('availabilityZone', 2)])
-        else:
-            self.cmd('{} flexible-server restore -g {} --name {} --source-server {} --restore-time {}'
-                     .format(database_engine, resource_group, restore_server, server, restore_time),
-                     checks=[JMESPathCheck('name', restore_server),
-                             JMESPathCheck('resourceGroup', resource_group)])
-        
-        self.cmd('{} flexible-server delete -g {} --name {} --yes'.format(database_engine, resource_group, restore_server))
+
+        try:
+            restore_time = datetime.utcnow().replace(tzinfo=tzutc()).isoformat()
+            if database_engine == 'postgres':
+                self.cmd('{} flexible-server restore -g {} --name {} --source-server {} --restore-time {}'
+                        .format(database_engine, resource_group, restore_server, server, restore_time),
+                        checks=[JMESPathCheck('name', restore_server),
+                                JMESPathCheck('resourceGroup', resource_group),
+                                JMESPathCheck('availabilityZone', 2)])
+            else:
+                self.cmd('{} flexible-server restore -g {} --name {} --source-server {} --restore-time {}'
+                        .format(database_engine, resource_group, restore_server, server, restore_time),
+                        checks=[JMESPathCheck('name', restore_server),
+                                JMESPathCheck('resourceGroup', resource_group)])
+        finally:
+            self.cmd('{} flexible-server delete -g {} --name {} --yes'.format(database_engine, resource_group, restore_server))
 
     def _test_flexible_server_high_availability_delete(self, database_engine, resource_group, server):
         self.cmd('{} flexible-server delete -g {} --name {} --yes'.format(database_engine, resource_group, server))


### PR DESCRIPTION
**Description**<!--Mandatory-->
When testing restoring servers using `_test_flexible_server_restore` and `_test_flexible_server_high_availability_restore`, if an assert fails then server is not deleted.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
